### PR TITLE
Update to vst 0.2,  allow custom window size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vst-gui"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Alexander Agafonov <vanderlokken@gmail.com>"]
 description = "An extension to the 'rust-vst' crate to create VST plugin GUIs"
 license = "MIT"
 keywords = ["gui", "plugin", "vst", "vst2"]
 
 [dependencies]
-vst = "^0.0"
+vst = "^0.2"
 
 [target.'cfg(windows)'.dependencies]
 memoffset = "0.2.1"

--- a/examples/synth.rs
+++ b/examples/synth.rs
@@ -99,7 +99,6 @@ struct ExampleSynth {
     // We access this object both from a UI thread and from an audio processing
     // thread.
     oscillator: Arc<Mutex<Oscillator>>,
-    gui: vst_gui::PluginGui,
 }
 
 impl Default for ExampleSynth {
@@ -116,9 +115,6 @@ impl Default for ExampleSynth {
         ExampleSynth {
             sample_rate: 44100.0,
             oscillator: oscillator.clone(),
-            gui: vst_gui::new_plugin_gui(
-                String::from(HTML),
-                create_javascript_callback(oscillator.clone())),
         }
     }
 }
@@ -168,8 +164,12 @@ impl Plugin for ExampleSynth {
         oscillator.phase = phase(buffer.samples()) % (2.0 * PI);
     }
 
-    fn get_editor(&mut self) -> Option<&mut Editor> {
-        Some(&mut self.gui)
+    fn get_editor(&mut self) -> Option<Box<dyn Editor>> {
+        let gui = vst_gui::new_plugin_gui(
+            String::from(HTML),
+            create_javascript_callback(self.oscillator.clone()),
+            None);
+        Some(Box::new(gui))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod lib {
         fn size(&self) -> (i32, i32);
         fn position(&self) -> (i32, i32);
         fn close(&mut self);
-        fn open(&mut self, parent_handle: *mut c_void);
+        fn open(&mut self, parent_handle: *mut c_void) -> bool;
         fn is_open(&mut self) -> bool;
         fn execute(&self, javascript_code: &str) -> Result<(), Box<Error>>;
     }
@@ -53,7 +53,7 @@ impl vst::editor::Editor for PluginGui {
         self.gui.close()
     }
 
-    fn open(&mut self, parent_handle: *mut c_void) {
+    fn open(&mut self, parent_handle: *mut c_void) -> bool {
         self.gui.open(parent_handle)
     }
 
@@ -65,10 +65,10 @@ impl vst::editor::Editor for PluginGui {
 pub use lib::JavascriptCallback;
 
 pub fn new_plugin_gui(
-    html_document: String, js_callback: JavascriptCallback) -> PluginGui
+    html_document: String, js_callback: JavascriptCallback, window_size: Option<(i32, i32)>) -> PluginGui
 {
     #[cfg(windows)]
     {
-        PluginGui {gui: win32::new_plugin_gui(html_document, js_callback)}
+        PluginGui {gui: win32::new_plugin_gui(html_document, js_callback, window_size) }
     }
 }


### PR DESCRIPTION
This fixes issue #3 and also updates the vst dependency to the latest (0.2) 

vst-0.2 is unfortunately a breaking change for existing users of rust-vst-gui so I suggest bumping the version of rust-vst-gui to 0.2.0 to match.